### PR TITLE
Port from the old DSL

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,3 +28,4 @@ addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.fu
 
 addCommandAlias("fmt", "all scalafmtSbt scalafmt test:scalafmt")
 addCommandAlias("chk", "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck")
+addCommandAlias("cvr", "; clean; coverage; test; coverageReport")

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
-val ZioVersion    = "1.0.0-RC11-1"
-val Specs2Version = "4.7.0"
+val ZioVersion       = "1.0.0-RC11-1"
+val Specs2Version    = "4.7.0"
+val ParboiledVersion = "2.1.8"
 
 resolvers += Resolver.sonatypeRepo("releases")
 resolvers += Resolver.sonatypeRepo("snapshots")
@@ -12,8 +13,9 @@ lazy val root = (project in file("."))
     scalaVersion := "2.12.9",
     maxErrors := 3,
     libraryDependencies ++= Seq(
-      "dev.zio"    %% "zio"         % ZioVersion,
-      "org.specs2" %% "specs2-core" % Specs2Version % "test"
+      "dev.zio"       %% "zio"         % ZioVersion,
+      "org.specs2"    %% "specs2-core" % Specs2Version % "test",
+      "org.parboiled" %% "parboiled"   % ParboiledVersion
     )
   )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
-addSbtPlugin("org.scalameta"             % "sbt-scalafmt" % "2.0.2")
-addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.7")
+addSbtPlugin("org.scalameta"             % "sbt-scalafmt"  % "2.0.2")
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat"  % "0.1.7")
+addSbtPlugin("org.scoverage"             % "sbt-scoverage" % "1.6.0")

--- a/src/main/scala/AST.scala
+++ b/src/main/scala/AST.scala
@@ -1,0 +1,114 @@
+package dsl
+
+import scala.reflect.ClassTag
+
+// TODO: Get rid of all the exceptions
+case class ParseException(message: String) extends Exception
+
+sealed trait AST extends Product with Serializable {
+  val valueType: ASTType
+
+  def metadata: PatternMetadata
+
+  def requireType(requirementType: ASTType, message: Any): Unit =
+    if (valueType != requirementType) throw ParseException(message.toString)
+}
+
+case class Constant[T](value: T)(implicit ct: ClassTag[T]) extends AST {
+  def metadata: PatternMetadata = PatternMetadata.empty
+
+  override val valueType: ASTType = ASTType.of[T]
+}
+
+case class Identifier(value: Symbol, tag: ClassTag[_]) extends AST {
+  override def metadata = PatternMetadata(Set(value), 0L)
+
+  override val valueType: ASTType = ASTType.of(tag)
+}
+
+case class Range[T](from: T, to: T)(implicit ct: ClassTag[T]) extends AST {
+  def metadata: PatternMetadata = PatternMetadata.empty
+
+  override val valueType: ASTType = ASTType.of[T]
+}
+
+case class FunctionCall(functionName: Symbol, arguments: Seq[AST])(implicit fr: FunctionRegistry) extends AST {
+  override def metadata = arguments.map(_.metadata).reduce(_ + _)
+  override val valueType: ASTType = fr.functions.get((functionName, arguments.map(_.valueType))) match {
+    case Some((_, t)) => t
+    case None =>
+      throw ParseException(
+        s"No function with name $functionName " +
+          s"and types (${arguments.map(_.valueType).mkString(", ")})"
+      )
+  }
+}
+
+case class ReducerFunctionCall(functionName: Symbol, @transient cond: Option[Any] => Boolean, arguments: Seq[AST])(
+  implicit fr: FunctionRegistry
+) extends AST {
+  // require the same type for all arguments
+  arguments.zipWithIndex.foreach {
+    case (a, idx) =>
+      a.requireType(
+        arguments(0).valueType,
+        s"Arguments must have the same type, but arg #1 is ${arguments(0).valueType} " +
+          s"and arg #${idx + 1} is ${a.valueType}"
+      )
+  }
+
+  override def metadata = arguments.map(_.metadata).reduce(_ + _)
+  override val valueType: ASTType = fr.reducers.get((functionName, arguments(0).valueType)) match {
+    case Some((_, t, _, _)) => t
+    case None =>
+      throw ParseException(
+        s"No reducer with name $functionName " +
+          s"and type ${arguments(0).valueType}"
+      )
+  }
+}
+
+case class AndThen(first: AST, second: AST) extends AST {
+  first.requireType(BooleanASTType, s"1st argument '$first' must be boolean in '$this'")
+  second.requireType(BooleanASTType, s"2nd argument '$second' must be boolean in '$this'")
+  override def metadata = first.metadata + second.metadata
+
+  override val valueType: ASTType = BooleanASTType
+}
+
+case class Timer(cond: AST, interval: TimeInterval, gap: Option[Window] = None) extends AST {
+  // Careful! Could be wrong, depending on the PatternMetadata.sumWindowsMs use-cases
+  override def metadata = cond.metadata + PatternMetadata(Set.empty, gap.map(_.toMillis).getOrElse(interval.max))
+
+  override val valueType: ASTType = BooleanASTType
+}
+
+case class Assert(cond: AST) extends AST {
+  override def metadata = cond.metadata
+
+  override val valueType: ASTType = BooleanASTType
+}
+
+/**
+ * Term for syntax like `X for [exactly] T TIME > 3 times`, where
+ * @param inner is `X`
+ * @param window is `T TIME`
+ * @param interval is `> 3 times`
+ * @param exactly special term to mark the for-expr as non-sort-circuiting
+ *                (ie run to the end, even if Option is obvious).
+ */
+case class ForWithInterval(inner: AST, exactly: Option[Boolean], window: Window, interval: Interval[Long]) extends AST {
+  override def metadata  = inner.metadata + PatternMetadata(Set.empty, window.toMillis)
+  override val valueType = BooleanASTType
+}
+
+case class AggregateCall(function: AggregateFn, value: AST, window: Window, gap: Option[Window] = None) extends AST {
+  override def metadata = value.metadata + PatternMetadata(Set.empty, gap.getOrElse(window).toMillis)
+
+  override val valueType: ASTType = DoubleASTType //TODO: Customize return type
+}
+
+case class Cast(inner: AST, to: ASTType) extends AST {
+  override val valueType: ASTType        = to
+  override def metadata: PatternMetadata = inner.metadata
+}

--- a/src/main/scala/ASTBuilder.scala
+++ b/src/main/scala/ASTBuilder.scala
@@ -1,0 +1,423 @@
+package dsl
+
+import org.parboiled2._
+
+import scala.language.higherKinds
+import scala.reflect.ClassTag
+
+class ASTBuilder(val input: ParserInput, toleranceFraction: Double, fieldsTags: Map[Symbol, ClassTag[_]])
+    extends Parser {
+
+  // TODO: Move to params
+  @transient implicit val funReg: FunctionRegistry = DefaultFunctionRegistry
+
+  def start: Rule1[AST] = rule {
+    trileanExpr ~ EOI
+  }
+
+  def trileanExpr: Rule1[AST] = rule {
+    trileanTerm ~ zeroOrMore(
+      ignoreCase("andthen") ~ ws ~ trileanTerm ~>
+        ((e: AST, f: AST) => AndThen(e, f))
+        | ignoreCase("and") ~ ws ~ trileanTerm ~>
+          ((e: AST, f: AST) => FunctionCall('and, Seq(e, f)))
+        | ignoreCase("or") ~ ws ~ trileanTerm ~>
+          ((e: AST, f: AST) => FunctionCall('or, Seq(e, f)))
+    )
+  }
+
+  // The following comment disables IDEA's type-aware inspection for a region (until the line with the same comment)
+  /*_*/
+  def trileanTerm: Rule1[AST] = rule {
+    (trileanFactor ~ ignoreCase("for") ~ ws ~ optional(ignoreCase("exactly") ~ ws ~> (() => true)) ~
+      time ~ range ~ ws ~> (ForWithInterval(_, _, _, _))
+      | nonFatalTrileanFactor ~ ignoreCase("for") ~ ws ~
+        (timeWithTolerance | timeBoundedRange) ~ ws ~> (buildForExpr(_, _))
+      | trileanFactor ~ ignoreCase("until") ~ ws ~ booleanExpr ~ optional(range) ~ ws ~>
+        ((c: AST, b: AST, r: Option[Any]) => {
+          val until          = Assert(FunctionCall('not, Seq(b)))
+          val timedCondition = Timer(c, TimeInterval(MaxWindow, MaxWindow), Some(MinWindow))
+          FunctionCall('and, Seq(timedCondition, until))
+        })
+      | trileanFactor)
+  }
+  /*_*/
+
+  protected def buildForExpr(phase: AST, ti: TimeInterval): AST =
+    Timer(Assert(phase.asInstanceOf[AST]), ti)
+
+  def nonFatalTrileanFactor: Rule1[AST] = rule {
+    booleanExpr | '(' ~ trileanExpr ~ ')' ~ ws
+  }
+
+  def trileanFactor: Rule1[AST] = rule {
+    booleanExpr ~> { b: AST =>
+      Assert(b)
+    } | '(' ~ trileanExpr ~ ')' ~ ws
+  }
+
+  def booleanExpr: Rule1[AST] = rule {
+    booleanTerm ~ zeroOrMore(
+      ignoreCase("or") ~ ws ~ booleanTerm ~>
+        ((e: AST, f: AST) => FunctionCall('or, Seq(e, f)))
+        | ignoreCase("xor") ~ ws ~ booleanTerm ~>
+          ((e: AST, f: AST) => FunctionCall('xor, Seq(e, f)))
+    )
+  }
+
+  def booleanTerm: Rule1[AST] = rule {
+    booleanFactor ~ zeroOrMore(
+      ignoreCase("and") ~ !ignoreCase("then") ~ ws ~ booleanFactor ~>
+        ((e: AST, f: AST) => FunctionCall('and, Seq(e, f)))
+    )
+  }
+
+  def booleanFactor: Rule1[AST] = rule {
+    comparison |
+      boolean |
+      "(" ~ booleanExpr ~ ")" ~ ws | "not" ~ booleanExpr ~> ((b: AST) => FunctionCall('not, Seq(b)))
+  }
+
+  def comparison: Rule1[AST] = rule {
+    (
+      expr ~ "<" ~ ws ~ expr ~> (
+        (
+          e1: AST,
+          e2: AST
+        ) => FunctionCall('lt, Seq(e1, e2))
+      )
+        | expr ~ "<=" ~ ws ~ expr ~> (
+          (
+            e1: AST,
+            e2: AST
+          ) => FunctionCall('le, Seq(e1, e2))
+        )
+        | expr ~ ">" ~ ws ~ expr ~> (
+          (
+            e1: AST,
+            e2: AST
+          ) => FunctionCall('gt, Seq(e1, e2))
+        )
+        | expr ~ ">=" ~ ws ~ expr ~> (
+          (
+            e1: AST,
+            e2: AST
+          ) => FunctionCall('ge, Seq(e1, e2))
+        )
+        | expr ~ "=" ~ ws ~ expr ~> (
+          (
+            e1: AST,
+            e2: AST
+          ) => FunctionCall('eq, Seq(e1, e2))
+        )
+        |
+          expr ~ ("!=" | "<>") ~ ws ~ expr ~> (
+            (
+              e1: AST,
+              e2: AST
+            ) => FunctionCall('ne, Seq(e1, e2))
+          )
+    )
+  }
+
+  def expr: Rule1[AST] = rule {
+    term ~ zeroOrMore(
+      '+' ~ ws ~ term ~> (
+        (
+          e: AST,
+          f: AST
+        ) => FunctionCall('add, Seq(e, f))
+      )
+        | '-' ~ ws ~ term ~> (
+          (
+            e: AST,
+            f: AST
+          ) => FunctionCall('sub, Seq(e, f))
+        )
+    )
+  }
+
+  def term: Rule1[AST] = rule {
+    factor ~
+      zeroOrMore(
+        '*' ~ ws ~ factor ~> (
+          (
+            e: AST,
+            f: AST
+          ) => FunctionCall('mul, Seq(e, f))
+        )
+          | '/' ~ ws ~ factor ~> (
+            (
+              e: AST,
+              f: AST
+            ) => FunctionCall('div, Seq(e, f))
+          )
+      )
+  }
+
+  /*_*/
+  def factor: Rule1[AST] = rule {
+    (
+      real
+        | boolean
+        | functionCall
+        | fieldValue
+        | '(' ~ expr ~ ')' ~ ws
+    ) ~ optional(ws ~ ignoreCase("as") ~ ws ~ typeName ~ ws) ~>
+      (
+        (
+          f: AST,            // expression
+          t: Option[ASTType] // which optionally can be cast to this type
+        ) =>
+          t match {
+            case Some(value) => Cast(f, value)
+            case None        => f
+          }
+        )
+  }
+  /*_*/
+
+  def typeName: Rule1[ASTType] = rule {
+    (
+      ignoreCase("int32") ~> (() => IntASTType)
+        | ignoreCase("int64") ~> (() => LongASTType)
+        | ignoreCase("float64") ~> (() => DoubleASTType)
+        | ignoreCase("boolean") ~> (() => BooleanASTType)
+        | ignoreCase("string") ~> (() => StringASTType)
+    )
+  }
+
+  def underscoreConstraint: Rule1[Double => Boolean] = rule {
+    underscoreConjunction ~ zeroOrMore(
+      ignoreCase("or") ~ ws ~ underscoreConjunction ~>
+        ((e: Double => Boolean, f: Double => Boolean) => (x: Double) => e(x) || f(x))
+        | ignoreCase("xor") ~ ws ~ underscoreConjunction ~>
+          ((e: Double => Boolean, f: Double => Boolean) => (x: Double) => e(x) != f(x))
+    )
+  }
+
+  def underscoreConjunction: Rule1[Double => Boolean] = rule {
+    underscoreCond ~ zeroOrMore(
+      ignoreCase("and") ~ ws ~ underscoreCond ~>
+        ((e: Double => Boolean, f: Double => Boolean) => (x: Double) => e(x) && f(x))
+    )
+  }
+
+  def underscoreCond: Rule1[Double => Boolean] = rule {
+    (
+      underscoreComparison
+        | boolean ~> ((e: Constant[Boolean]) => (_: Double) => e.value)
+        | '(' ~ underscoreConstraint ~ ')'
+        | ignoreCase("not") ~ underscoreCond ~> ((e: Double => Boolean) => (x: Double) => !e(x))
+    )
+  }
+
+  def underscoreComparison: Rule1[Double => Boolean] = rule {
+    (
+      underscoreExpr ~ "<" ~ ws ~ underscoreExpr ~>
+        ((e: Double => Double, f: Double => Double) => (x: Double) => e(x) < f(x))
+        | underscoreExpr ~ "<=" ~ ws ~ underscoreExpr ~>
+          ((e: Double => Double, f: Double => Double) => (x: Double) => e(x) <= f(x))
+        | underscoreExpr ~ ">" ~ ws ~ underscoreExpr ~>
+          ((e: Double => Double, f: Double => Double) => (x: Double) => e(x) > f(x))
+        | underscoreExpr ~ ">=" ~ ws ~ underscoreExpr ~>
+          ((e: Double => Double, f: Double => Double) => (x: Double) => e(x) >= f(x))
+        | underscoreExpr ~ "=" ~ ws ~ underscoreExpr ~>
+          ((e: Double => Double, f: Double => Double) => (x: Double) => e(x) == f(x))
+        | underscoreExpr ~ ("!=" | "<>") ~ ws ~ underscoreExpr ~>
+          ((e: Double => Double, f: Double => Double) => (x: Double) => e(x) != f(x))
+    )
+  }
+
+  def underscoreExpr: Rule1[Double => Double] = rule {
+    underscoreTerm ~
+      zeroOrMore(
+        '+' ~ ws ~ underscoreTerm ~> ((e: Double => Double, f: Double => Double) => (x: Double) => e(x) + f(x))
+          | '-' ~ ws ~ underscoreTerm ~> ((e: Double => Double, f: Double => Double) => (x: Double) => e(x) - f(x))
+      )
+  }
+
+  def underscoreTerm: Rule1[Double => Double] = rule {
+    underscoreFactor ~
+      zeroOrMore(
+        '*' ~ ws ~ underscoreFactor ~> ((e: Double => Double, f: Double => Double) => (x: Double) => e(x) * f(x))
+          | '/' ~ ws ~ underscoreFactor ~> ((e: Double => Double, f: Double => Double) => (x: Double) => e(x) / f(x))
+      )
+  }
+
+  def underscoreFactor: Rule1[Double => Double] = rule {
+    (
+      real ~ ws ~> ((r: Constant[Double]) => (_: Double) => r.value)
+        | long ~ ws ~>
+          ((r: Constant[Long]) => (_: Double) => r.value.toDouble)
+        | str("_") ~ ws ~> (() => (x: Double) => x)
+        | '(' ~ underscoreExpr ~ ')' ~ ws
+    )
+  }
+
+  def range: Rule1[Interval[Long]] = rule {
+    timeRange | repetitionRange
+  }
+
+  def timeRange: Rule1[TimeInterval] = rule {
+    ("<" ~ ws ~ time ~> ((t: Window) => TimeInterval.less(t))
+      | "<=" ~ ws ~ time ~> ((t: Window) => TimeInterval.less(t))
+      | ">" ~ ws ~ time ~> ((t: Window) => TimeInterval.more(t))
+      | ">=" ~ ws ~ time ~> ((t: Window) => TimeInterval.more(t))
+      | timeBoundedRange)
+  }
+
+  def timeBoundedRange: Rule1[TimeInterval] = rule {
+    (time ~ ignoreCase("to") ~ ws ~ time ~>
+      ((t1: Window, t2: Window) => TimeInterval(t1, t2))
+      | real ~ ignoreCase("to") ~ ws ~ real ~ timeUnit ~>
+        (
+          (
+            d1: Constant[Double],
+            d2: Constant[Double],
+            u: Int
+          ) =>
+            TimeInterval(
+              Window((d1.value * u).toLong),
+              Window((d2.value * u).toLong)
+            )
+          ))
+  }
+
+  def repetitionRange: Rule1[NumericInterval[Long]] = rule {
+    ("<" ~ ws ~ repetition ~> ((t: Long) => NumericInterval(0L, t))
+      | "<=" ~ ws ~ repetition ~> ((t: Long) => NumericInterval(0L, t + 1L))
+      | ">" ~ ws ~ repetition ~> ((t: Long) => NumericInterval.more(t + 1L))
+      | ">=" ~ ws ~ repetition ~> ((t: Long) => NumericInterval.more(t))
+      | long ~ ignoreCase("to") ~ ws ~ repetition ~>
+        ((t1: Constant[Long], t2: Long) => NumericInterval(t1.value, t2)))
+  }
+
+  def repetition: Rule1[Long] = rule {
+    long ~ ignoreCase("times") ~> ((e: Constant[Long]) => e.value)
+  }
+
+  def time: Rule1[Window] = rule {
+    singleTime.+(ws) ~> (
+      (ts: Seq[Window]) =>
+        Window(ts.foldLeft(0L) { (acc, t) =>
+          acc + t.toMillis
+        })
+      )
+  }
+
+  def timeWithTolerance: Rule1[TimeInterval] = rule {
+    (time ~ ws ~ "+-" ~ ws ~ time ~> (
+      (
+        win: Window,
+        tol: Window
+      ) => TimeInterval(Window(Math.max(win.toMillis - tol.toMillis, 0)), Window(win.toMillis + tol.toMillis))
+    )
+      | time ~ ws ~ "+-" ~ ws ~ real ~ ws ~ "%" ~> (
+        (
+          win: Window,
+          tolPc: Constant[Double]
+        ) => {
+          val tol = (tolPc.value * 0.01 * win.toMillis).toLong
+          TimeInterval(Window(Math.max(win.toMillis - tol, 0)), Window(win.toMillis + tol))
+        }
+      )
+      | time ~> ((win: Window) => {
+        val tol = (win.toMillis * toleranceFraction).toLong
+        TimeInterval(Window(Math.max(win.toMillis - tol, 0)), Window(win.toMillis + tol))
+      }))
+  }
+
+  def singleTime: Rule1[Window] = rule {
+    real ~ timeUnit ~ ws ~>
+      ((i: Constant[Double], u: Int) => Window((i.value * u).toLong))
+  }
+
+  def timeUnit: Rule1[Int] = rule {
+    (ignoreCase("seconds") ~> (() => 1000)
+      | ignoreCase("sec") ~> (() => 1000)
+      | ignoreCase("minutes") ~> (() => 60000)
+      | ignoreCase("min") ~> (() => 60000)
+      | ignoreCase("milliseconds") ~> (() => 1)
+      | ignoreCase("ms") ~> (() => 1)
+      | ignoreCase("hours") ~> (() => 3600000)
+      | ignoreCase("hr") ~> (() => 3600000))
+  }
+
+  def real: Rule1[Constant[Double]] = rule {
+    // sign of a number: positive (or empty) = 1, negative = -1
+    ((str("+") ~> (() => 1) | str("-") ~> (() => -1) | str("") ~> (() => 1)) ~
+      capture(oneOrMore(CharPredicate.Digit) ~ optional('.' ~ oneOrMore(CharPredicate.Digit))) ~ ws
+      ~> ((sign: Int, i: String) => Constant(sign * i.toDouble)))
+  }
+
+  def long: Rule1[Constant[Long]] = rule {
+    // sign of a number: positive (or empty) = 1, negative = -1
+    ((str("+") ~> (() => 1) | str("-") ~> (() => -1) | str("") ~> (() => 1))
+      ~ capture(oneOrMore(CharPredicate.Digit)) ~ ws
+      ~> ((s: Int, i: String) => Constant(s * i.toLong)))
+  }
+
+  /*_*/
+  def functionCall: Rule1[AST] = rule {
+    (
+      anyWord ~ ws ~ "(" ~ ws ~ expr.*(ws ~ "," ~ ws) ~ optional(";" ~ ws ~ underscoreConstraint) ~ ws ~ ")" ~ ws ~>
+        ((function: String, arguments: Seq[AST], constraint: Option[Double => Boolean]) => {
+          // TODO: Convention about function naming?
+          val normalisedFunction = function.toLowerCase
+          val c                  = constraint.getOrElse((_: Double) => true)
+          normalisedFunction match {
+            case x if x.endsWith("of") =>
+              ReducerFunctionCall(
+                Symbol(normalisedFunction),
+                (x: Option[Any]) => c(x.getOrElse(Double.NaN).asInstanceOf[Double]),
+                arguments
+              )
+            case "lag" =>
+              if (arguments.length > 1)
+                throw ParseException("Lag should use only 1 argument when called without window")
+              AggregateCall(Lag, arguments.head, Window(1), Some(Window(0)))
+            case _ => FunctionCall(Symbol(normalisedFunction), arguments)
+          }
+        })
+        | anyWord ~ ws ~ "(" ~ ws ~ expr ~ ws ~ "," ~ ws ~ time ~ ws ~ ")" ~ ws ~>
+          (
+            (
+              function: String,
+              arg: AST,
+              win: Window
+            ) => {
+              AggregateCall(AggregateFn.fromSymbol(Symbol(function)).right.get, arg, win)
+            }
+          )
+    )
+  }
+  /*_*/
+
+  def anyWord: Rule1[String] = rule {
+    ((capture(CharPredicate.Alpha ~ zeroOrMore(CharPredicate.AlphaNum | '_')) ~ ws)
+      | (anyWordInDblQuotes ~> ((id: String) => id.replace("\"\"", "\""))))
+  }
+
+  def anyWordInDblQuotes: Rule1[String] = rule {
+    '"' ~ capture(oneOrMore(noneOf("\"") | "\"\"")) ~ '"' ~ ws
+  }
+
+  def fieldValue: Rule1[Identifier] = rule {
+    anyWord ~> ((id: String) => {
+      fieldsTags.get(Symbol(id)) match {
+        case Some(tag) => Identifier(Symbol(id), tag)
+        case None      => throw ParseException(s"Unknown identifier (field) $id")
+      }
+    })
+  }
+
+  def boolean: Rule1[Constant[Boolean]] = rule {
+    (ignoreCase("true") ~ ws ~> (() => Constant(true))
+      | ignoreCase("false") ~ ws ~> (() => Constant(false)) ~ ws)
+  }
+
+  def ws = rule {
+    quiet(zeroOrMore(anyOf(" \t \n \r")))
+  }
+}

--- a/src/main/scala/ASTType.scala
+++ b/src/main/scala/ASTType.scala
@@ -1,0 +1,41 @@
+package dsl
+
+import scala.reflect.ClassTag
+
+trait ASTType
+
+case object IntASTType     extends ASTType
+case object LongASTType    extends ASTType
+case object BooleanASTType extends ASTType
+case object DoubleASTType  extends ASTType
+case object StringASTType  extends ASTType
+case object AnyASTType     extends ASTType
+
+object ASTType {
+
+  def of[T](implicit ct: ClassTag[T]): ASTType = ct.runtimeClass match {
+    // Basic check, if T isn't lost
+    case c if c.isAssignableFrom(classOf[Double])  => DoubleASTType
+    case c if c.isAssignableFrom(classOf[Long])    => LongASTType
+    case c if c.isAssignableFrom(classOf[Int])     => IntASTType
+    case c if c.isAssignableFrom(classOf[Boolean]) => BooleanASTType
+    case c if c.isAssignableFrom(classOf[String])  => StringASTType
+
+    // Extra check, in case type T i lost
+    case c
+        if isNamesMatch(
+          c,
+          Seq(Double.getClass, Float.getClass, classOf[java.lang.Double], classOf[java.lang.Float])
+        ) =>
+      DoubleASTType
+    case c if isNamesMatch(c, Seq(Long.getClass, classOf[java.lang.Long]))       => LongASTType
+    case c if isNamesMatch(c, Seq(Int.getClass, classOf[java.lang.Integer]))     => IntASTType
+    case c if isNamesMatch(c, Seq(Boolean.getClass, classOf[java.lang.Boolean])) => BooleanASTType
+    case c if isNamesMatch(c, Seq(classOf[java.lang.String]))                    => StringASTType
+
+    case _ => AnyASTType
+  }
+
+  private def isNamesMatch(tag: Class[_], classes: Seq[Class[_]]) =
+    classes.map(_.getName).contains(tag.getName)
+}

--- a/src/main/scala/FunctionRegistry.scala
+++ b/src/main/scala/FunctionRegistry.scala
@@ -1,0 +1,498 @@
+package dsl
+import java.io.Serializable
+
+import scala.reflect.ClassTag
+
+@SerialVersionUID(81001L)
+trait PFunction extends (Seq[Any] => Option[Any]) with Serializable
+
+@SerialVersionUID(81002L)
+trait PReducer extends ((Option[Any], Any) => Option[Any]) with Serializable
+
+@SerialVersionUID(81003L)
+trait PReducerTransformation extends (Option[Any] => Option[Any]) with Serializable
+
+/**
+ * Registry for runtime functions
+ * Ensure that the Option type of the function matches the corresponding ASTType. It's not automatic
+ *
+ * @param functions Multi-argument functions (arguments wrapped into a Seq) and their return types
+ * @param reducers Reducer functions, their return types and initial values
+ */
+case class FunctionRegistry(
+  @transient functions: Map[(Symbol, Seq[ASTType]), (PFunction, ASTType)],
+  @transient reducers: Map[(Symbol, ASTType), (PReducer, ASTType, PReducerTransformation, Serializable)]
+) {
+
+  def ++(other: FunctionRegistry) = FunctionRegistry(functions ++ other.functions, reducers ++ other.reducers)
+}
+
+object DefaultFunctions {
+
+  private def toOption[T](x: Any)(implicit ct: ClassTag[T]): Option[T] =
+    x match {
+      case value: Option[T]                                          => value
+      case value: T                                                  => Some(value)
+      case value if ct.runtimeClass.isAssignableFrom(value.getClass) => Some(value.asInstanceOf[T])
+      case v: Long if (ct.runtimeClass eq classOf[Int]) || (ct.runtimeClass eq classOf[java.lang.Integer]) =>
+        Some(v.toInt.asInstanceOf[T]) // we know that T == Int
+      case v: Long if (ct.runtimeClass eq classOf[Double]) || (ct.runtimeClass eq classOf[java.lang.Double]) =>
+        Some(v.toDouble.asInstanceOf[T]) // we know that T == Double
+      // TODO: maybe some other cases
+      case _ =>
+        None
+    }
+
+  def arithmeticFunctions[T1: ClassTag, T2: ClassTag](
+    implicit f: Fractional[T1],
+    conv: T2 => T1
+  ): Map[(Symbol, Seq[ASTType]), (PFunction, ASTType)] = {
+    val astType1: ASTType = ASTType.of[T1]
+    val astType2: ASTType = ASTType.of[T2]
+    def func(f: (T1, T2) => T1): (PFunction, ASTType) = (
+      (xs: Seq[Any]) =>
+        (toOption[T1](xs.head), toOption[T2](xs(1))) match {
+          case (Some(t0), Some(t1)) => Some(f(t0, t1))
+          case _                    => None
+        },
+      astType1
+    )
+    Map(
+      ('add, Seq(astType1, astType2)) -> func(f.plus(_, _)),
+      ('sub, Seq(astType1, astType2)) -> func(f.minus(_, _)),
+      ('mul, Seq(astType1, astType2)) -> (
+        (
+          (xs: Seq[Any]) =>
+            (toOption[T1](xs(0)), toOption[T2](xs(1))) match {
+              case (Some(t0), Some(t1)) => Some(f.times(t0, t1))
+              case _                    => None
+            },
+          astType1
+        )
+      ),
+      ('div, Seq(astType1, astType2)) -> (
+        (
+          (xs: Seq[Any]) =>
+            (toOption[T1](xs(0)), toOption[T2](xs(1))) match {
+              case (Some(t0), Some(t1)) => Some(f.div(t0, t1))
+              case _                    => None
+            },
+          astType1
+        )
+      ),
+      ('add, Seq(astType2, astType1)) -> (
+        (
+          (xs: Seq[Any]) =>
+            (toOption[T2](xs(0)), toOption[T1](xs(1))) match {
+              case (Some(t0), Some(t1)) => Some(f.plus(t0, t1))
+              case _                    => None
+            },
+          astType1
+        )
+      ),
+      ('sub, Seq(astType2, astType1)) -> (
+        (
+          (xs: Seq[Any]) =>
+            (toOption[T2](xs(0)), toOption[T1](xs(1))) match {
+              case (Some(t0), Some(t1)) => Some(f.minus(t0, t1))
+              case _                    => None
+            },
+          astType1
+        )
+      ),
+      ('mul, Seq(astType2, astType1)) -> (
+        (
+          (xs: Seq[Any]) =>
+            (toOption[T2](xs(0)), toOption[T1](xs(1))) match {
+              case (Some(t0), Some(t1)) => Some(f.times(t0, t1))
+              case _                    => None
+            },
+          astType1
+        )
+      ),
+      ('div, Seq(astType2, astType1)) -> (
+        (
+          (xs: Seq[Any]) =>
+            (toOption[T2](xs(0)), toOption[T1](xs(1))) match {
+              case (Some(t0), Some(t1)) => Some(f.div(t0, t1))
+              case _                    => None
+            },
+          astType1
+        )
+      )
+    )
+  }
+
+  def mathFunctions[T: ClassTag](implicit conv: T => Double): Map[(Symbol, Seq[ASTType]), (PFunction, ASTType)] = {
+    val astType = ASTType.of[T]
+    Map(
+      ('abs, Seq(astType)) -> (
+        (
+          (xs: Seq[Any]) => toOption[T](xs(0)).map(Math.abs(_)),
+          astType
+        )
+      ),
+      ('sin, Seq(astType)) -> (
+        (
+          (xs: Seq[Any]) => toOption[T](xs(0)).map(Math.sin(_)),
+          astType
+        )
+      ),
+      ('cos, Seq(astType)) -> (
+        (
+          (xs: Seq[Any]) => toOption[T](xs(0)).map(Math.cos(_)),
+          astType
+        )
+      ),
+      ('tan, Seq(astType)) -> (
+        (
+          (xs: Seq[Any]) => toOption[T](xs(0)).map(Math.tan(_)),
+          astType
+        )
+      ),
+      ('tg, Seq(astType)) -> (
+        (
+          (xs: Seq[Any]) => toOption[T](xs(0)).map(Math.tan(_)),
+          astType
+        )
+      ),
+      ('cot, Seq(astType)) -> (
+        (
+          (xs: Seq[Any]) => toOption[T](xs(0)).map(1.0 / Math.tan(_)),
+          astType
+        )
+      ),
+      ('ctg, Seq(astType)) -> (
+        (
+          (xs: Seq[Any]) => toOption[T](xs(0)).map(1.0 / Math.tan(_)),
+          astType
+        )
+      ),
+      ('sind, Seq(astType)) -> (
+        (
+          (xs: Seq[Any]) => toOption[T](xs(0)).map(x => Math.toRadians(Math.sin(x))),
+          astType
+        )
+      ),
+      ('cosd, Seq(astType)) -> (
+        (
+          (xs: Seq[Any]) => toOption[T](xs(0)).map(x => Math.toRadians(Math.cos(x))),
+          astType
+        )
+      ),
+      ('tand, Seq(astType)) -> (
+        (
+          (xs: Seq[Any]) => toOption[T](xs(0)).map(x => Math.toRadians(Math.tan(x))),
+          astType
+        )
+      ),
+      ('tgd, Seq(astType)) -> (
+        (
+          (xs: Seq[Any]) => toOption[T](xs(0)).map(x => Math.toRadians(Math.sin(x))),
+          astType
+        )
+      ),
+      ('cotd, Seq(astType)) -> (
+        (
+          (xs: Seq[Any]) => toOption[T](xs(0)).map(x => 1.0 / Math.toRadians(Math.tan(x))),
+          astType
+        )
+      ),
+      ('ctgd, Seq(astType)) -> (
+        (
+          (xs: Seq[Any]) => toOption[T](xs(0)).map(x => 1.0 / Math.toRadians(Math.tan(x))),
+          astType
+        )
+      )
+    )
+  }
+
+  def logicalFunctions: Map[(Symbol, Seq[ASTType]), (PFunction, ASTType)] = {
+
+    // TSP-182 - Workaround for correct type inference
+
+    val btype = BooleanASTType
+
+    def func(sym: Symbol, xs: Seq[Any])(implicit l: Logical[Any]): Option[Boolean] =
+      //log.debug(s"func($sym): Arg0 = $xs(0), Arg1 = $xs(1)")
+      //log.info(s"Args = ${(xs(0), xs.lift(1).getOrElse(Unit))}")
+      //log.info(s"Arg Options = ${(toOption[Boolean](xs(0)), toOption[Boolean](xs.lift(1).getOrElse(Unit)))}")
+      (toOption[Boolean](xs(0)), toOption[Boolean](xs.lift(1).getOrElse(Unit))) match {
+        case (Some(x0), Some(x1)) =>
+          sym match {
+
+            case 'and => Some(l.and(x0, x1))
+            case 'or  => Some(l.or(x0, x1))
+            case 'xor => Some(l.xor(x0, x1))
+            case 'eq  => Some(l.eq(x0, x1))
+            case 'neq => Some(l.neq(x0, x1))
+            case _    => None
+          }
+        case (Some(x0), None) =>
+          sym match {
+            case 'not => Some(l.not(x0))
+            case _    => None
+          }
+        case _ => None
+      }
+
+    Map(
+      //('and , Seq(btype, btype))  -> (((xs: Seq[Any]) => xs.foldLeft(true) {_.asInstanceOf[Boolean] && _.asInstanceOf[Boolean]}, btype)),
+      //('or  , Seq(btype, btype))  -> (((xs: Seq[Any]) => xs.foldLeft(true) {_.asInstanceOf[Boolean] || _.asInstanceOf[Boolean]}, btype)),
+      ('and, Seq(btype, btype)) -> (((xs: Seq[Any]) => func('and, xs), btype)),
+      ('or, Seq(btype, btype))  -> (((xs: Seq[Any]) => func('or, xs), btype)),
+      ('xor, Seq(btype, btype)) -> (((xs: Seq[Any]) => func('xor, xs), btype)),
+      ('eq, Seq(btype, btype))  -> (((xs: Seq[Any]) => func('eq, xs), btype)),
+      ('neq, Seq(btype, btype)) -> (((xs: Seq[Any]) => func('neq, xs), btype)),
+      ('not, Seq(btype))        -> (((xs: Seq[Any]) => func('not, xs), btype))
+    )
+  }
+
+  def comparingFunctions[T1: ClassTag, T2: ClassTag](
+    implicit ord: Ordering[T1],
+    conv: T2 => T1
+  ): Map[(Symbol, Seq[ASTType]), (PFunction, ASTType)] = {
+    val astType1: ASTType = ASTType.of[T1]
+    val astType2: ASTType = ASTType.of[T2]
+    Map(
+      ('lt, Seq(astType1, astType2)) -> (
+        (
+          (xs: Seq[Any]) =>
+            (toOption[T1](xs(0)), toOption[T2](xs(1))) match {
+              case (Some(t0), Some(t1)) => Some(ord.lt(t0, t1))
+              case _                    => None
+            },
+          BooleanASTType
+        )
+      ),
+      ('le, Seq(astType1, astType2)) -> (
+        (
+          (xs: Seq[Any]) =>
+            (toOption[T1](xs(0)), toOption[T2](xs(1))) match {
+              case (Some(t0), Some(t1)) => Some(ord.lteq(t0, t1))
+              case _                    => None
+            },
+          BooleanASTType
+        )
+      ),
+      ('gt, Seq(astType1, astType2)) -> (
+        (
+          (xs: Seq[Any]) =>
+            (toOption[T1](xs(0)), toOption[T2](xs(1))) match {
+              case (Some(t0), Some(t1)) => Some(ord.gt(t0, t1))
+              case _                    => None
+            },
+          BooleanASTType
+        )
+      ),
+      ('ge, Seq(astType1, astType2)) -> (
+        (
+          (xs: Seq[Any]) =>
+            (toOption[T1](xs(0)), toOption[T2](xs(1))) match {
+              case (Some(t0), Some(t1)) => Some(ord.gteq(t0, t1))
+              case _                    => None
+            },
+          BooleanASTType
+        )
+      ),
+      ('eq, Seq(astType1, astType2)) -> (
+        (
+          (xs: Seq[Any]) =>
+            (toOption[T1](xs(0)), toOption[T2](xs(1))) match {
+              case (Some(t0), Some(t1)) => Some(ord.equiv(t0, t1))
+              case _                    => None
+            },
+          BooleanASTType
+        )
+      ),
+      ('ne, Seq(astType1, astType2)) -> (
+        (
+          (xs: Seq[Any]) =>
+            (toOption[T1](xs(0)), toOption[T2](xs(1))) match {
+              case (Some(t0), Some(t1)) => Some(!ord.equiv(t0, t1))
+              case _                    => None
+            },
+          BooleanASTType
+        )
+      ),
+      ('lt, Seq(astType2, astType1)) -> (
+        (
+          (xs: Seq[Any]) =>
+            (toOption[T2](xs(0)), toOption[T1](xs(1))) match {
+              case (Some(t0), Some(t1)) => Some(ord.lt(t0, t1))
+              case _                    => None
+            },
+          BooleanASTType
+        )
+      ),
+      ('le, Seq(astType2, astType1)) -> (
+        (
+          (xs: Seq[Any]) =>
+            (toOption[T2](xs(0)), toOption[T1](xs(1))) match {
+              case (Some(t0), Some(t1)) => Some(ord.lteq(t0, t1))
+              case _                    => None
+            },
+          BooleanASTType
+        )
+      ),
+      ('gt, Seq(astType2, astType1)) -> (
+        (
+          (xs: Seq[Any]) =>
+            (toOption[T2](xs(0)), toOption[T1](xs(1))) match {
+              case (Some(t0), Some(t1)) => Some(ord.gt(t0, t1))
+              case _                    => None
+            },
+          BooleanASTType
+        )
+      ),
+      ('ge, Seq(astType2, astType1)) -> (
+        (
+          (xs: Seq[Any]) =>
+            (toOption[T2](xs(0)), toOption[T1](xs(1))) match {
+              case (Some(t0), Some(t1)) => Some(ord.gteq(t0, t1))
+              case _                    => None
+            },
+          BooleanASTType
+        )
+      ),
+      ('eq, Seq(astType2, astType1)) -> (
+        (
+          (xs: Seq[Any]) =>
+            (toOption[T2](xs(0)), toOption[T1](xs(1))) match {
+              case (Some(t0), Some(t1)) => Some(ord.equiv(t0, t1))
+              case _                    => None
+            },
+          BooleanASTType
+        )
+      ),
+      ('ne, Seq(astType2, astType1)) -> (
+        (
+          (xs: Seq[Any]) =>
+            (toOption[T2](xs(0)), toOption[T1](xs(1))) match {
+              case (Some(t0), Some(t1)) => Some(!ord.equiv(t0, t1))
+              case _                    => None
+            },
+          BooleanASTType
+        )
+      )
+    )
+  }
+
+  def reducers[T: ClassTag](
+    implicit conv: T => Double
+  ): Map[(Symbol, ASTType), (PReducer, ASTType, PReducerTransformation, Serializable)] = Map(
+    ('sumof, DoubleASTType) -> (
+      (
+        { (acc: Option[Any], x: Any) =>
+          (toOption[Double](acc), toOption[Double](x)) match {
+            case (Some(da), Some(dx)) => Some(da + dx)
+            case _                    => None
+          }
+        },
+        DoubleASTType, {
+          identity(_)
+        },
+        java.lang.Double.valueOf(0)
+      )
+    ),
+    ('minof, DoubleASTType) -> (
+      (
+        { (acc: Option[Any], x: Any) =>
+          (toOption[Double](acc), toOption[Double](x)) match {
+            case (Some(da), Some(dx)) => Some(Math.min(da, dx))
+            case _                    => None
+          }
+        },
+        DoubleASTType, {
+          identity(_)
+        },
+        java.lang.Double.valueOf(Double.MaxValue)
+      )
+    ),
+    ('maxof, DoubleASTType) -> (
+      (
+        { (acc: Option[Any], x: Any) =>
+          (toOption[Double](acc), toOption[Double](x)) match {
+            case (Some(da), Some(dx)) => Some(Math.max(da, dx))
+            case _                    => None
+          }
+        },
+        DoubleASTType, {
+          identity(_)
+        },
+        java.lang.Double.valueOf(Double.MinValue)
+      )
+    ),
+    /*('countof, DoubleASTType) -> ({ (acc: Option[Any], x: Any) =>
+      (toOption[Double](acc), toOption[Double](x)) match {
+        case (Some(da), Some(_)) => Some(da + 1)
+        case _                   => None
+      }
+    }, DoubleASTType, {
+      identity(_)
+    }, java.lang.Double.valueOf(0)),*/
+    ('avgof, DoubleASTType) -> (({ (acc: Option[Any], x: Any) =>
+      (toOption[(Double, Double)](acc), toOption[Double](x)) match {
+        case (Some((sum, count)), Some(dx)) => Some((sum + dx, count + 1))
+        case _                              => None
+      }
+    }, DoubleASTType, { x: Option[Any] =>
+      x match {
+        case Some((sum: Double, count: Double)) => Some(sum / count)
+        case _                                  => None
+      }
+    }, (0.0, 0.0)))
+  )
+
+  // Fractional type for Int and Long to allow division
+
+  implicit val fractionalInt: Fractional[Int] = new Fractional[Int] {
+    override def div(x: Int, y: Int): Int     = x / y
+    override def plus(x: Int, y: Int): Int    = x + y
+    override def minus(x: Int, y: Int): Int   = x - y
+    override def times(x: Int, y: Int): Int   = x * y
+    override def negate(x: Int): Int          = -x
+    override def fromInt(x: Int): Int         = x
+    override def toInt(x: Int): Int           = x
+    override def toLong(x: Int): Long         = x
+    override def toFloat(x: Int): Float       = x.toFloat
+    override def toDouble(x: Int): Double     = x.toDouble
+    override def compare(x: Int, y: Int): Int = java.lang.Long.compare(x, y)
+  }
+
+  implicit val fractionalLong: Fractional[Long] = new Fractional[Long] {
+    override def div(x: Long, y: Long): Long    = x / y
+    override def plus(x: Long, y: Long): Long   = x + y
+    override def minus(x: Long, y: Long): Long  = x - y
+    override def times(x: Long, y: Long): Long  = x * y
+    override def negate(x: Long): Long          = -x
+    override def fromInt(x: Int): Long          = x
+    override def toInt(x: Long): Int            = x.toInt
+    override def toLong(x: Long): Long          = x
+    override def toFloat(x: Long): Float        = x.toFloat
+    override def toDouble(x: Long): Double      = x.toDouble
+    override def compare(x: Long, y: Long): Int = java.lang.Long.compare(x, y)
+  }
+}
+
+import DefaultFunctions._
+
+object DefaultFunctionRegistry
+    extends FunctionRegistry(
+      functions = arithmeticFunctions[Int, Int] ++
+        arithmeticFunctions[Long, Long] ++
+        arithmeticFunctions[Long, Int] ++
+        arithmeticFunctions[Double, Double] ++
+        arithmeticFunctions[Double, Long] ++
+        arithmeticFunctions[Double, Int] ++
+        mathFunctions[Int] ++
+        mathFunctions[Long] ++
+        mathFunctions[Double] ++
+        logicalFunctions ++
+        comparingFunctions[Int, Int] ++
+        comparingFunctions[Long, Long] ++
+        comparingFunctions[Double, Double] ++
+        comparingFunctions[Double, Long] ++
+        comparingFunctions[Double, Int],
+      reducers = reducers[Int] ++ reducers[Long] ++ reducers[Double]
+    )

--- a/src/main/scala/FunctionRegistry.scala
+++ b/src/main/scala/FunctionRegistry.scala
@@ -170,37 +170,37 @@ object DefaultFunctions {
       ),
       ('sind, Seq(astType)) -> (
         (
-          (xs: Seq[Any]) => toOption[T](xs(0)).map(x => Math.toRadians(Math.sin(x))),
+          (xs: Seq[Any]) => toOption[T](xs(0)).map(x => (Math.sin(Math.toRadians(x)))),
           astType
         )
       ),
       ('cosd, Seq(astType)) -> (
         (
-          (xs: Seq[Any]) => toOption[T](xs(0)).map(x => Math.toRadians(Math.cos(x))),
+          (xs: Seq[Any]) => toOption[T](xs(0)).map(x => (Math.cos(Math.toRadians(x)))),
           astType
         )
       ),
       ('tand, Seq(astType)) -> (
         (
-          (xs: Seq[Any]) => toOption[T](xs(0)).map(x => Math.toRadians(Math.tan(x))),
+          (xs: Seq[Any]) => toOption[T](xs(0)).map(x => (Math.tan(Math.toRadians(x)))),
           astType
         )
       ),
       ('tgd, Seq(astType)) -> (
         (
-          (xs: Seq[Any]) => toOption[T](xs(0)).map(x => Math.toRadians(Math.sin(x))),
+          (xs: Seq[Any]) => toOption[T](xs(0)).map(x => (Math.sin(Math.toRadians(x)))),
           astType
         )
       ),
       ('cotd, Seq(astType)) -> (
         (
-          (xs: Seq[Any]) => toOption[T](xs(0)).map(x => 1.0 / Math.toRadians(Math.tan(x))),
+          (xs: Seq[Any]) => toOption[T](xs(0)).map(x => 1.0 / (Math.tan(Math.toRadians(x)))),
           astType
         )
       ),
       ('ctgd, Seq(astType)) -> (
         (
-          (xs: Seq[Any]) => toOption[T](xs(0)).map(x => 1.0 / Math.toRadians(Math.tan(x))),
+          (xs: Seq[Any]) => toOption[T](xs(0)).map(x => 1.0 / (Math.tan(Math.toRadians(x)))),
           astType
         )
       )

--- a/src/main/scala/Functional.scala
+++ b/src/main/scala/Functional.scala
@@ -1,0 +1,27 @@
+package dsl
+import scala.language.higherKinds
+
+// Logical Functions typeclass
+trait Logical[T] {
+
+  def and(a: T, b: T): Boolean
+  def or(a: T, b: T): Boolean
+  def xor(a: T, b: T): Boolean
+  def eq(a: T, b: T): Boolean
+  def neq(a: T, b: T): Boolean
+  def not(a: T): Boolean
+}
+
+object Logical {
+
+  implicit val AnyLogical: Logical[Any] = new Logical[Any] {
+
+    def and(a: Any, b: Any): Boolean = a.asInstanceOf[Boolean] && b.asInstanceOf[Boolean]
+    def or(a: Any, b: Any): Boolean  = a.asInstanceOf[Boolean] || b.asInstanceOf[Boolean]
+    def xor(a: Any, b: Any): Boolean = a.asInstanceOf[Boolean] ^ b.asInstanceOf[Boolean]
+    def eq(a: Any, b: Any): Boolean  = a.asInstanceOf[Boolean] == b.asInstanceOf[Boolean] // FIXME ===
+    def neq(a: Any, b: Any): Boolean = a.asInstanceOf[Boolean] != b.asInstanceOf[Boolean] // FIXME =!=
+    def not(a: Any): Boolean         = !a.asInstanceOf[Boolean]
+
+  }
+}

--- a/src/main/scala/Functions.scala
+++ b/src/main/scala/Functions.scala
@@ -1,0 +1,18 @@
+package dsl
+
+sealed trait AggregateFn extends Product with Serializable
+case object Sum          extends AggregateFn
+case object Count        extends AggregateFn
+case object Avg          extends AggregateFn
+case object Lag          extends AggregateFn
+
+object AggregateFn {
+
+  def fromSymbol(name: Symbol): Either[String, AggregateFn] = name match {
+    case 'sum   => Right(Sum)
+    case 'count => Right(Count)
+    case 'avg   => Right(Avg)
+    case 'lag   => Right(Lag)
+    case _      => Left(s"Unknown aggregator '$name'")
+  }
+}

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -1,15 +1,15 @@
-package hello
-
-import zio.App
-import zio.console.{ putStrLn }
-
-object Main extends App {
-
-  def run(args: List[String]) =
-    myAppLogic.fold(_ => 1, _ => 0)
-
-  val myAppLogic =
-    for {
-      _ <- putStrLn("Hello World")
-    } yield ()
-}
+//package hello
+//
+//import zio.App
+//import zio.console.{ putStrLn }
+//
+//object Main extends App {
+//
+//  def run(args: List[String]) =
+//    myAppLogic.fold(_ => 1, _ => 0)
+//
+//  val myAppLogic =
+//    for {
+//      _ <- putStrLn("Hello World")
+//    } yield ()
+//}

--- a/src/main/scala/PatternMetadata.scala
+++ b/src/main/scala/PatternMetadata.scala
@@ -1,0 +1,10 @@
+package dsl
+
+case class PatternMetadata(fields: Set[Symbol], sumWindowsMs: Long) {
+  def +(other: PatternMetadata): PatternMetadata =
+    PatternMetadata(fields ++ other.fields, sumWindowsMs + other.sumWindowsMs)
+}
+
+object PatternMetadata {
+  val empty = PatternMetadata(Set.empty, 0L)
+}

--- a/src/main/scala/Temp.scala
+++ b/src/main/scala/Temp.scala
@@ -1,0 +1,50 @@
+package dsl
+
+// TimeIntervals, windows, etc.
+// TODO: Remove this stuff, it's temporary. It must be in another project
+
+case class Window(toMillis: Long) extends Serializable
+
+object MinWindow extends Window(toMillis = 0L)
+
+object MaxWindow extends Window(toMillis = Long.MaxValue)
+
+object Window {
+  def less(w: Window) = TimeInterval(max = w)
+
+  def more(w: Window) = TimeInterval(min = w)
+}
+
+trait Interval[T] {
+  def contains(value: T): Boolean
+  def isInfinite: Boolean
+}
+
+/** Inclusive-exclusive interval of time */
+case class TimeInterval(min: Long, max: Long) extends Interval[Long] {
+  override def contains(w: Long): Boolean = w >= min && w <= max
+
+  override def isInfinite: Boolean = max == MaxWindow.toMillis
+}
+
+object TimeInterval {
+  def apply(min: Window = MinWindow, max: Window = MaxWindow): TimeInterval = TimeInterval(min.toMillis, max.toMillis)
+
+  val MaxInterval = TimeInterval(MaxWindow, MaxWindow)
+
+  def less(value: Window): TimeInterval = TimeInterval(0L, value.toMillis)
+
+  def more(value: Window): TimeInterval = TimeInterval(value.toMillis, Long.MaxValue)
+}
+
+case class NumericInterval[T](min: T, max: T)(implicit num: Numeric[T]) extends Interval[T] {
+  override def contains(value: T): Boolean = num.gteq(value, min) && num.lteq(value, max)
+
+  override def isInfinite: Boolean = num.toLong(max) == Long.MaxValue
+}
+
+object NumericInterval {
+  def less[T](value: T)(implicit num: Numeric[T]): NumericInterval[T] = NumericInterval(num.zero, value)
+
+  def more[T](value: T)(implicit num: Numeric[T]): NumericInterval[T] = NumericInterval(value, ???)
+}

--- a/src/test/scala/ASTTest.scala
+++ b/src/test/scala/ASTTest.scala
@@ -1,0 +1,91 @@
+package dsl
+import org.specs2._
+
+import scala.reflect.ClassTag
+
+class ASTTest extends mutable.Specification {
+  implicit val funReg = DefaultFunctionRegistry
+
+  "Specification for AST testing" >> {
+    "AST types must correctly construct from Scala types" >> {
+      ASTType.of[Int] must be(IntASTType)
+      ASTType.of[java.lang.Integer] must be(IntASTType)
+      ASTType.of[Long] must be(LongASTType)
+      ASTType.of[java.lang.Long] must be(LongASTType)
+      ASTType.of[Boolean] must be(BooleanASTType)
+      ASTType.of[java.lang.Boolean] must be(BooleanASTType)
+      ASTType.of[Double] must be(DoubleASTType)
+      ASTType.of[java.lang.Double] must be(DoubleASTType)
+      ASTType.of[String] must be(StringASTType)
+      ASTType.of[List[Int]] must be(AnyASTType)
+    }
+
+    "AST types must correctly determine" >> {
+      Constant(1.0).valueType must be(DoubleASTType)
+      Constant(1L).valueType must be(LongASTType)
+      Constant(true).valueType must be(BooleanASTType)
+      Constant(List(1, 2, 3)).valueType must be(AnyASTType)
+    }
+
+    "Identifiers must have correct types" >> {
+      Identifier('intVar, ClassTag.Int).valueType must be(IntASTType)
+      Identifier('longVar, ClassTag.Long).valueType must be(LongASTType)
+      Identifier('boolVar, ClassTag.Boolean).valueType must be(BooleanASTType)
+      Identifier('doubleVar, ClassTag.Double).valueType must be(DoubleASTType)
+      Identifier('stringVar, ClassTag(classOf[String])).valueType must be(StringASTType)
+    }
+
+    "AST operations must require types" >> {
+      FunctionCall('and, Seq(Constant(true), Constant(false))).valueType must be(BooleanASTType)
+      FunctionCall('and, Seq(Constant(true))) must throwA[ParseException]              // only 1 argument
+      FunctionCall('and, Seq(Constant(true), Constant(1))) must throwA[ParseException] // invalid types
+    }
+
+    "Reducers must control types" >> {
+      ReducerFunctionCall('sumof, (_ => true), Seq(Constant(5.0), Constant(8.0))).valueType must be(DoubleASTType)
+      ReducerFunctionCall('sumof, (_ => true), Seq(Constant(true), Constant(13.0))) must throwA[ParseException] // invalid types
+      ReducerFunctionCall('samof, (_ => true), Seq(Constant(5.0), Constant(8.0))) must throwA[ParseException]   // invalid reducername
+    }
+
+    "AndThen must control types" >> {
+      AndThen(Constant(true), Constant(true)).valueType must be(BooleanASTType)
+      AndThen(Constant(true), Constant(1.0)).valueType must throwA[ParseException] // non-boolean second argument
+      AndThen(Constant(1.0), Constant(true)).valueType must throwA[ParseException] // non-boolean first argument
+    }
+
+    "Windowed operators must construct correctly" >> {
+      val winOp = ForWithInterval(
+        FunctionCall('gt, Seq(Identifier('sensor, ClassTag.Double), Constant(0))),
+        Some(false),
+        Window(60000),
+        TimeInterval(0, 10000)
+      )
+      winOp.valueType must be(BooleanASTType)
+      winOp.metadata mustEqual (PatternMetadata(Set('sensor), 60000))
+    }
+
+    "Type requirements must be met" >> {
+      Constant(10L).requireType(LongASTType, "Type was not long")
+      Constant(10L).requireType(BooleanASTType, "Type was not boolean") must throwA[ParseException]
+    }
+
+    "Aggregate functions must be correctly created from symbols" >> {
+      AggregateFn.fromSymbol('sum) must beRight(Sum)
+      AggregateFn.fromSymbol('avg) must beRight(Avg)
+      AggregateFn.fromSymbol('count) must beRight(Count)
+      AggregateFn.fromSymbol('lag) must beRight(Lag)
+      AggregateFn.fromSymbol('invalid) must beLeft
+    }
+
+    "Aggregate calls must correctly determine window sizes" >> {
+      AggregateCall(Sum, Constant(1), Window(10000)).metadata.sumWindowsMs mustEqual 10000L
+      AggregateCall(Sum, AggregateCall(Avg, Constant(1.0), Window(5000)), Window(10000)).metadata.sumWindowsMs mustEqual 15000L
+    }
+
+    "Range must be correctly constructed" >> {
+      val range = Range(10000L, 60000L)
+      range.metadata must be(PatternMetadata.empty)
+      range.valueType must be(LongASTType)
+    }
+  }
+}

--- a/src/test/scala/FunctionRegistryTest.scala
+++ b/src/test/scala/FunctionRegistryTest.scala
@@ -1,0 +1,148 @@
+package dsl
+
+import org.specs2._
+
+class FunctionRegistryTest extends mutable.Specification {
+  val funReg = DefaultFunctionRegistry
+  //implicit val doubleEq: Equality[Double] = TolerantNumerics.tolerantDoubleEquality(1e-6)
+
+  "Function registry specification " >> {
+    "Function registry boolean functions must be callable" >> {
+      funReg.functions(('and, Seq(BooleanASTType, BooleanASTType)))._1(Seq(true, false)) must beSome(false)
+      funReg.functions(('or, Seq(BooleanASTType, BooleanASTType)))._1(Seq(false, true)) must beSome(true)
+      funReg.functions(('xor, Seq(BooleanASTType, BooleanASTType)))._1(Seq(true, true)) must beSome(false)
+      funReg.functions(('eq, Seq(BooleanASTType, BooleanASTType)))._1(Seq(true, true)) must beSome(true)
+      funReg.functions(('neq, Seq(BooleanASTType, BooleanASTType)))._1(Seq(true, true)) must beSome(false)
+      funReg.functions(('not, Seq(BooleanASTType)))._1(Seq(true)) must beSome(false)
+    }
+
+    "Function registry arithmetic functions with double must be callable" >> {
+      funReg.functions(('add, Seq(DoubleASTType, DoubleASTType)))._1(Seq(5.0, 8.0)) must beSome(13.0)
+      funReg.functions(('sub, Seq(DoubleASTType, DoubleASTType)))._1(Seq(29.0, 16.0)) must beSome(13.0)
+      funReg.functions(('mul, Seq(DoubleASTType, DoubleASTType)))._1(Seq(13.0, 1.0)) must beSome(13.0)
+      funReg.functions(('div, Seq(DoubleASTType, DoubleASTType)))._1(Seq(78.0, 6.0)) must beSome(13.0)
+    }
+
+    "Function registry arithmetic functions with long must be callable" >> {
+      funReg.functions(('add, Seq(LongASTType, LongASTType)))._1(Seq(5L, 8L)) must beSome(13L)
+      funReg.functions(('sub, Seq(LongASTType, LongASTType)))._1(Seq(29L, 16L)) must beSome(13L)
+      funReg.functions(('mul, Seq(LongASTType, LongASTType)))._1(Seq(13L, 1L)) must beSome(13L)
+      funReg.functions(('div, Seq(LongASTType, LongASTType)))._1(Seq(78L, 6L)) must beSome(13L)
+    }
+
+    "Function registry arithmetic functions with int must be callable" >> {
+      funReg.functions(('add, Seq(IntASTType, IntASTType)))._1(Seq(5, 8)) must beSome(13)
+      funReg.functions(('sub, Seq(IntASTType, IntASTType)))._1(Seq(29, 16)) must beSome(13)
+      funReg.functions(('mul, Seq(IntASTType, IntASTType)))._1(Seq(13, 1)) must beSome(13)
+      funReg.functions(('div, Seq(IntASTType, IntASTType)))._1(Seq(78, 6)) must beSome(13)
+    }
+
+    "Function registry arithmetic functions with mixed types must be callable" >> {
+      funReg.functions(('add, Seq(DoubleASTType, IntASTType)))._1(Seq[Any](5.0, 8)) must beSome(13.0)
+      funReg.functions(('sub, Seq(DoubleASTType, IntASTType)))._1(Seq[Any](29.0, 16)) must beSome(13.0)
+      funReg.functions(('mul, Seq(DoubleASTType, IntASTType)))._1(Seq[Any](13.0, 1)) must beSome(13.0)
+      funReg.functions(('div, Seq(DoubleASTType, IntASTType)))._1(Seq[Any](78.0, 6)) must beSome(13.0)
+    }
+
+    "Math functions must be callable" >> {
+      // We need `.asInstanceOf[Double]` here to enable tolerant comparison
+      funReg
+        .functions(('abs, Seq(DoubleASTType)))
+        ._1(Seq(-1.0))
+        .getOrElse(Double.NaN)
+        .asInstanceOf[Double] must be ~ (1.0 +/- 1e-5)
+      funReg
+        .functions(('sin, Seq(DoubleASTType)))
+        ._1(Seq(Math.PI / 2))
+        .getOrElse(Double.NaN)
+        .asInstanceOf[Double] must be ~ (1.0 +/- 1e-5)
+      funReg
+        .functions(('cos, Seq(DoubleASTType)))
+        ._1(Seq(Math.PI / 2))
+        .getOrElse(Double.NaN)
+        .asInstanceOf[Double] must be ~ (0.0 +/- 1e-5)
+      funReg
+        .functions(('tan, Seq(DoubleASTType)))
+        ._1(Seq(Math.PI / 4))
+        .getOrElse(Double.NaN)
+        .asInstanceOf[Double] must be ~ (1.0 +/- 1e-5)
+      funReg
+        .functions(('tg, Seq(DoubleASTType)))
+        ._1(Seq(Math.PI / 4))
+        .getOrElse(Double.NaN)
+        .asInstanceOf[Double] must be ~ (1.0 +/- 1e-5)
+      funReg
+        .functions(('cot, Seq(DoubleASTType)))
+        ._1(Seq(Math.PI / 4))
+        .getOrElse(Double.NaN)
+        .asInstanceOf[Double] must be ~ (1.0 +/- 1e-5)
+      funReg
+        .functions(('ctg, Seq(DoubleASTType)))
+        ._1(Seq(Math.PI / 4))
+        .getOrElse(Double.NaN)
+        .asInstanceOf[Double] must be ~ (1.0 +/- 1e-5)
+      funReg
+        .functions(('sind, Seq(DoubleASTType)))
+        ._1(Seq(30.0))
+        .getOrElse(Double.NaN)
+        .asInstanceOf[Double] must be ~ (0.5 +/- 1e-5)
+      funReg
+        .functions(('cosd, Seq(DoubleASTType)))
+        ._1(Seq(60.0))
+        .getOrElse(Double.NaN)
+        .asInstanceOf[Double] must be ~ (0.5 +/- 1e-5)
+      funReg
+        .functions(('tand, Seq(DoubleASTType)))
+        ._1(Seq(45.0))
+        .getOrElse(Double.NaN)
+        .asInstanceOf[Double] must be ~ (1.0 +/- 1e-5)
+      funReg
+        .functions(('tgd, Seq(DoubleASTType)))
+        ._1(Seq(0.0))
+        .getOrElse(Double.NaN)
+        .asInstanceOf[Double] must be ~ (0.0 +/- 1e-5)
+      funReg
+        .functions(('cotd, Seq(DoubleASTType)))
+        ._1(Seq(45.0))
+        .getOrElse(Double.NaN)
+        .asInstanceOf[Double] must be ~ (1.0 +/- 1e-5)
+      funReg
+        .functions(('ctgd, Seq(DoubleASTType)))
+        ._1(Seq(90.0))
+        .getOrElse(Double.NaN)
+        .asInstanceOf[Double] must be ~ (0.0 +/- 1e-5)
+    }
+
+    "Function registry comparison functions with double must be callable" >> {
+      funReg.functions(('lt, Seq(DoubleASTType, DoubleASTType)))._1(Seq(5.0, 8.0)) must beSome(true)
+      funReg.functions(('le, Seq(DoubleASTType, DoubleASTType)))._1(Seq(29.0, 18.0)) must beSome(false)
+      funReg.functions(('gt, Seq(DoubleASTType, DoubleASTType)))._1(Seq(13.0, 12.0)) must beSome(true)
+      funReg.functions(('ge, Seq(DoubleASTType, DoubleASTType)))._1(Seq(5.0, 6.0)) must beSome(false)
+      funReg.functions(('eq, Seq(DoubleASTType, DoubleASTType)))._1(Seq(4.0, 4.0)) must beSome(true)
+      funReg.functions(('ne, Seq(DoubleASTType, DoubleASTType)))._1(Seq(21.0, 6.0)) must beSome(true)
+    }
+
+    "Function registry comparison functions with mixed types must be callable" >> {
+      funReg.functions(('lt, Seq(DoubleASTType, IntASTType)))._1(Seq[Any](5.0, 8)) must beSome(true)
+      funReg.functions(('le, Seq(DoubleASTType, IntASTType)))._1(Seq[Any](29.0, 18)) must beSome(false)
+      funReg.functions(('gt, Seq(DoubleASTType, IntASTType)))._1(Seq[Any](13.0, 12)) must beSome(true)
+      funReg.functions(('ge, Seq(DoubleASTType, IntASTType)))._1(Seq[Any](5.0, 6)) must beSome(false)
+      funReg.functions(('eq, Seq(DoubleASTType, IntASTType)))._1(Seq[Any](4.0, 4)) must beSome(true)
+      funReg.functions(('ne, Seq(DoubleASTType, IntASTType)))._1(Seq[Any](21.0, 6)) must beSome(true)
+    }
+
+    "Function registry concatenation must work" >> {
+      // currently no other registries exist
+      funReg ++ funReg mustEqual funReg
+    }
+
+    "Function registry reducers must be callable" >> {
+      funReg.reducers(('sumof, DoubleASTType))._1(Some(5.0), Some(8.0)) must beSome(13.0)
+      funReg.reducers(('minof, DoubleASTType))._1(Some(5.0), Some(8.0)) must beSome(5.0)
+      funReg.reducers(('maxof, DoubleASTType))._1(Some(5.0), Some(8.0)) must beSome(8.0)
+      funReg.reducers(('sumof, DoubleASTType))._1(None, Some(8.0)) must beNone
+      funReg.reducers(('minof, DoubleASTType))._1(None, Some(8.0)) must beNone
+      funReg.reducers(('maxof, DoubleASTType))._1(None, Some(8.0)) must beNone
+    }
+  }
+}


### PR DESCRIPTION
- Added DSL classes from the old project (parser, ASTs, etc), except from ones that depend on `core` (e.g. `PatternGenerator`), since the latter is not ported yet. Some helper classes like `Window` and `TimeInterval` are temporarily implemented in here.
- Tests from the old project are ported from ScalaTest to Specs2.
- Added `scoverage` plugin and `cvr` command alias to get coverage reports at once.